### PR TITLE
Update README to remove note about enabling Service Worker; it is enable...

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,7 @@
 
 https://offline-news-service-worker.herokuapp.com
 
-Warnings:
-
-- You must enable Service Worker first - [instructions for Chrome](http://serviceworker.io/service-worker-in-chrome-canary.html)
-- I've only tested this in [Google Chrome Canary](https://www.google.co.uk/intl/en/chrome/browser/canary.html)
+Warning: I've only tested this in [Google Chrome Canary](https://www.google.co.uk/intl/en/chrome/browser/canary.html)
 
 ### Prerequisites for runing locally
 


### PR DESCRIPTION
...d by default in Chrome 40 and later.
